### PR TITLE
Initial benchmark setup with hyperfine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,3 +1813,12 @@ OCaml) and [prettier](https://prettier.io/) (for Markdown).
 2. Run `dune-release tag VERSION` to create a tag for the new `VERSION`.
 3. Run `dune-release` to publish the new `VERSION`.
 4. Run `./update-gh-pages-for-tag VERSION` to update the online documentation.
+
+## Benchmarks
+
+### To create benchmarks
+
+1. Install [hyperfine](https://github.com/sharkdp/hyperfine)
+2. Create a new benchmark file inside `/benchmarks` (e.g. `/benchmarks/my_benchmark.ml`)
+3. Add the new benchmark as an executable `/benchmarks/dune`
+4. Run the benchmark as `hyperfine 'dune exec benchmarks/my_benchmark.exe'`

--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -1,0 +1,3 @@
+(executable
+ (name queue_simple)
+ (libraries kcas kcas_data))

--- a/benchmarks/queue_simple.ml
+++ b/benchmarks/queue_simple.ml
@@ -1,0 +1,26 @@
+module Queue = Kcas_data.Queue
+
+let () =
+  print_endline "Queue simple benchmark";
+
+  let queue = Queue.create () in
+
+  let rec loop_enqueue i =
+    match i with
+    | 0 -> ()
+    | _ ->
+        Queue.push i queue;
+        loop_enqueue (i - 1)
+  in
+
+  let rec loop_dequeue i =
+    match i with
+    | 0 -> ()
+    | _ ->
+        let _ = Queue.take queue in
+        loop_dequeue (i - 1)
+  in
+
+  let _ = loop_enqueue 100000 in
+  let _ = loop_dequeue 100000 in
+  ()


### PR DESCRIPTION
Present a minimum benchmark test with hyperfine. 

1. Download and install hyperfine as an executable
2. Write each benchmark as a separate executable
3. Run hyperfine. Can add these runs into a makefile script. Hyperfine can also print out its results as markdown or json to display in github’s ui.